### PR TITLE
Fix deprecated use of use_texture_alpha for Minetest 5.4+

### DIFF
--- a/items.lua
+++ b/items.lua
@@ -33,7 +33,7 @@ minetest.register_node("claycrafter:glass_of_water", {
 	inventory_image = "claycrafter_glass_of_water_inv.png",
 	wield_image = "claycrafter_glass_of_water.png",
 	paramtype = "light",
-	use_texture_alpha = true,
+	use_texture_alpha = "blend",
 	is_ground_content = false,
 	walkable = false,
 	sunlight_propagates = true,


### PR DESCRIPTION
Change use_texture_alpha = true to use_texture_alpha = "blend"